### PR TITLE
Adding .xcodesamplecode.plist to give proper markdown rending inside …

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>


### PR DESCRIPTION
Same contents as my [merged PR into swift-crypto](https://github.com/apple/swift-crypto/pull/11) and my [merged PR into swift-numerics](https://github.com/apple/swift-numerics/pull/34), giving proper markdown rendering inside Xcode.

As seen in [Apple's ARKit demo (inside `/ARKitExample.xcodeproj/` directory)](https://developer.apple.com/sample-code/wwdc/2017/PlacingObjects.zip)

### Motivation:

Reading of markdown becomes easier. Extra important in Swift packages, where the `README` is the first file opened by Xcode when opening said package.

### Modifications:

Just adding the `.xcodesamplecode.plist` file (to the root).

### Result:


This effectively disables editing markdown files from Xcode - or at least I have not found a way of doing so.

The "workaround" is just to open markdown files with your favourite alternative text editor, e.g. emacs, VIM, VI, Sublime Text or whatever

#### Before:
<img width="1792" alt="before" src="https://user-images.githubusercontent.com/864410/74854641-e5b34e80-533f-11ea-8cce-6c3ae8be5a97.png">

#### After:
<img width="1792" alt="after" src="https://user-images.githubusercontent.com/864410/74854597-d92ef600-533f-11ea-9d57-a717c2185b2f.png">
