### PR TITLE
Explicitly import Foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 import PackageDescription
+import Foundation
 
 /// Details about an SE package.
 struct Export {


### PR DESCRIPTION
Using `capitalized` requires Foundation.