### PR TITLE
Add SE-0288 `isPower(of:)` to the preview package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,7 @@ struct Export {
 /// The list of SE packages to re-export.
 let exports = [
   Export(package: "swift-se0270-range-set", requirement: .upToNextMajor(from: "1.0.0")),
+  Export(package: "swift-se0288-is-power", requirement: .upToNextMajor(from: "1.0.0")),
 ]
 
 /// The `StandardLibraryPreview` package definition.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ re-exporting each of the individual packages.
   Operations on noncontiguous subranges of collections, 
   such as `subranges(where:)` and `moveSubranges(_:to:)`, 
   as well as the supporting `RangeSet` type.
+- [**`SE0288_IsPower`**](https://github.com/apple/swift-se0288-is-power/):
+  Extends `BinaryInteger` with an `isPower(of:)` method that returns whether
+  an integer is a power of another.
 
 ## Usage
 

--- a/Sources/StandardLibraryPreview/StandardLibraryPreview.swift
+++ b/Sources/StandardLibraryPreview/StandardLibraryPreview.swift
@@ -12,3 +12,4 @@
 // Export the included libraries in order of acceptance here:
 
 @_exported import SE0270_RangeSet
+@_exported import SE0288_IsPower

--- a/Tests/ExportTests/SE0288_Tests.swift
+++ b/Tests/ExportTests/SE0288_Tests.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------*- swift -*-===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+//
+//===----------------------------------------------------------------------===//
+
+import SE0288_IsPower
+import XCTest
+
+final class SE0288_Tests: XCTestCase {
+  func test_SE02288_IsPower() {
+    XCTAssertTrue(1024.isPower(of: 2))
+    XCTAssertTrue(6561.isPower(of: 3))
+    XCTAssertTrue(1000.isPower(of: 10))
+
+    XCTAssertFalse(1000.isPower(of: 2))
+    XCTAssertFalse(1024.isPower(of: 3))
+    XCTAssertFalse(6561.isPower(of: 10))
+  }
+}

--- a/Tests/ExportTests/UmbrellaTests.swift
+++ b/Tests/ExportTests/UmbrellaTests.swift
@@ -31,4 +31,14 @@ final class UmbrellaTests: XCTestCase {
       StandardLibraryPreview.RangeSet<Int>.self
         == SE0270_RangeSet.RangeSet<Int>.self)
   }
+
+  func test_SE02288_IsPower() {
+    XCTAssertTrue(1024.isPower(of: 2))
+    XCTAssertTrue(6561.isPower(of: 3))
+    XCTAssertTrue(1000.isPower(of: 10))
+
+    XCTAssertFalse(1000.isPower(of: 2))
+    XCTAssertFalse(1024.isPower(of: 3))
+    XCTAssertFalse(6561.isPower(of: 10))
+  }
 }


### PR DESCRIPTION
Depends on https://github.com/apple/swift-se0288-is-power/pull/1, and subsequently tagging a 1.0.0 version.